### PR TITLE
SPF check whitelisted domains

### DIFF
--- a/filter-greylist.go
+++ b/filter-greylist.go
@@ -263,10 +263,13 @@ func rcptTo(s *session, params []string) {
 	key = fmt.Sprintf("domain=%s", s.fromDomain)
 	if val, ok := whitelist_domain[key]; ok {
 		if s.tm - val < *whiteexp {
-			fmt.Fprintf(os.Stderr, "domain %s is whitelisted\n", s.fromDomain)
-			proceed(s.id, token)
-			whitelist_domain[key] = s.tm
-			return
+			res, _ := spf.CheckHostWithSender(s.ip, s.heloName, s.mailFrom)
+			if (res == "pass") {
+				fmt.Fprintf(os.Stderr, "domain %s is whitelisted\n", s.fromDomain)
+				proceed(s.id, token)
+				whitelist_domain[key] = s.tm
+				return
+			}
 		}
 	}
 

--- a/filter-greylist.go
+++ b/filter-greylist.go
@@ -316,11 +316,11 @@ func spfResolve(s *session, token string) {
 	defer gl_dom_mux.Unlock()
 	key := fmt.Sprintf("domain=%s:%s:%s", s.fromDomain, s.mailFrom, s.rcptTo)
 	domain2whitelist := false
-	if ! spfdomainwl {
+	if ! *spfdomainwl {
 		if val, ok := greylist_domain[key]; ok {
 			delta := s.tm - val
 			if val != s.tm && delta < *greyexp && delta > *passtime {
-				domain2whitelist := true
+				domain2whitelist = true
 			}
 		} else {
 			fmt.Fprintf(os.Stderr, "domain %s added to greylist\n", s.fromDomain)
@@ -331,7 +331,7 @@ func spfResolve(s *session, token string) {
 			return
 		}
 	}
-	if spfdomainwl || domain2whitelist {
+	if *spfdomainwl || domain2whitelist {
 		fmt.Fprintf(os.Stderr, "domain %s added to whitelist\n", s.fromDomain)
 		proceed(s.id, token)
 		key = fmt.Sprintf("domain=%s", s.fromDomain)
@@ -472,7 +472,7 @@ func main() {
 	whiteexp  = flag.Int64("whiteexp", 30*86400, "number of seconds before whitelists expire (default: 30 days)")
 	ip_wl     = flag.String("wl-ip", "", "filename containing a list of IP addresses to whitelist, one per line")
 	domain_wl = flag.String("wl-domain", "", "filename containing a list of sender domains to whitelist, one per line")
-	spfdomainwl = flag.String("spfdomainwl", false, "when =true enable domains with valid SPF autowhitelist mode (default: false)")
+	spfdomainwl = flag.Bool("spfdomainwl", false, "when =true enable domains with valid SPF autowhitelist mode (default: false)")
 
 	flag.Parse()
 


### PR DESCRIPTION
Hi Gilles, I think it would make sense to do SPF check whitelisted domains, otherwise they might be abused by spammers, i.e. without this check as soon as "@gmail.com" gets whitelisted anyone with mail-from "@gmail.com" will bypass greylisting.
