### PR TITLE
Always SPF check whitelisted domains

### DIFF
--- a/filter-greylist.go
+++ b/filter-greylist.go
@@ -263,10 +263,13 @@ func rcptTo(s *session, params []string) {
 	key = fmt.Sprintf("domain=%s", s.fromDomain)
 	if val, ok := whitelist_domain[key]; ok {
 		if s.tm - val < *whiteexp {
-			fmt.Fprintf(os.Stderr, "domain %s is whitelisted\n", s.fromDomain)
-			proceed(s.id, token)
-			whitelist_domain[key] = s.tm
-			return
+			res, _ := spf.CheckHostWithSender(s.ip, s.heloName, s.mailFrom)
+			if (res == "pass") {
+				fmt.Fprintf(os.Stderr, "domain %s is whitelisted\n", s.fromDomain)
+				proceed(s.id, token)
+				whitelist_domain[key] = s.tm
+				return
+			}
 		}
 	}
 


### PR DESCRIPTION
It would make sense to do SPF check with whitelisted domains, otherwise they might be abused by spammers, i.e. as soon as "@gmail.com" gets whitelisted anyone with mail-from "@gmail.com" will bypass greylisting.