### PR TITLE
Update go.yml to use go 1.22

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v4
       with:
-        go-version: '1.20'
+        go-version: '1.22'
 
     - name: Build
       run: go build -v ./...


### PR DESCRIPTION
In order to use ossec.Pledge, go 1.22 should be used and tested.

Fixes PR#7